### PR TITLE
modules: provide a `smallstring` C++20 module (and keep the Assert() hook alive)

### DIFF
--- a/include/smallstring.hpp
+++ b/include/smallstring.hpp
@@ -13,6 +13,26 @@
  */
 
 #pragma once
+// smallstring reads fmt textually, always -- header-only, module consumer, module interface alike. It
+// never imports fmt, in any configuration.
+//
+// It can afford to be that blunt because fmt, if it is a module at all, has to be built with
+// FMT_ATTACH_TO_GLOBAL_MODULE: seastar reaches fmt through <fmt/format.h> in ~21 of its headers and
+// will keep doing so, so fmt's declarations must stay attached to the global module or nothing in the
+// tree links. That macro is precisely what makes textual and imported fmt the *same* entities ("you
+// can mix TUs with either importing or #including the {fmt} API" -- fmt's own words), so a textual
+// read here meets an imported fmt anywhere else in the program.
+//
+// The converse does not hold, which is why there is no `import fmt;` branch to balance this one: the
+// fmt::formatter<basic_small_string> specialisation below derives from fmt::formatter<std::string_view>,
+// and through an import that base resolves to fmt's *primary* template -- "no member named 'parse'",
+// deleted constructor. That is fmt's behaviour, not smallstring's (a TU that does nothing but
+// `import fmt;` and name fmt::formatter<std::string_view> fails identically), and it is why every
+// attempt to route this header's fmt through the module has been a bug.
+#if defined(STDB_USE_FMT_MODULE) && !defined(FMT_ATTACH_TO_GLOBAL_MODULE)
+#error "smallstring reads fmt textually and specialises fmt::formatter, so an fmt built as a C++20 module must be built with FMT_ATTACH_TO_GLOBAL_MODULE -- otherwise its declarations attach to module `fmt` and the textual ones here cannot match them."
+#endif
+
 // Owned by module `smallstring` when the consumer builds with modules (SMALLSTRING_USE_MODULE).
 //
 // Outside that module the include degrades to the import, so these declarations are not ALSO
@@ -30,21 +50,9 @@
 // sits in its global module fragment and a GMF is not re-exported, so `import smallstring;` alone would
 // silently take fmt away from every consumer the moment SMALLSTRING_USE_MODULE is turned on.
 //
-// Keeping the include here costs nothing -- fmt is textual on both sides of the module boundary.
-//
-// Under STDB_USE_FMT_MODULE it is textual on *one* side: the interface unit reads <fmt/format.h>
-// textually no matter what, and only the consumer imports. Those still meet, because fmt's module is
-// required to be built with FMT_ATTACH_TO_GLOBAL_MODULE, which leaves its declarations attached to
-// the global module -- the same entities the interface unit saw. smallstring.cppm #errors if that is
-// not so, and explains why it cannot simply `import fmt;` instead.
-#if defined(STDB_USE_FMT_MODULE)
-#ifndef STDB_FMT_IMPORTED
-#define STDB_FMT_IMPORTED 1
-import fmt;
-#endif
-#else
+// Keeping the include here costs nothing: it is the same <fmt/format.h> the interface unit read, and
+// under FMT_ATTACH_TO_GLOBAL_MODULE (see the top of this file) the same entities either way.
 #include <fmt/format.h>
-#endif
 
 import smallstring;
 
@@ -68,19 +76,8 @@ import smallstring;
 #include <type_traits>
 #include <utility>
 
-// fmt is textual here, and stays textual even when the rest of the build has fmt as a C++20 module
-// (STDB_USE_FMT_MODULE). This is the branch that carries the *body*, so it is the branch that
-// *defines* fmt::formatter<basic_small_string> -- and that definition derives from
-// fmt::formatter<std::string_view>. Reached through `import fmt;`, that base resolves to fmt's
-// primary template and the header does not compile: "no member named 'parse' in
-// 'fmt::formatter<std::basic_string_view<char>>'", deleted constructor.
-//
-// (The import is fine in the SMALLSTRING_USE_MODULE branch above, and only there, because that
-// branch never parses this body -- the specialisation arrives ready-made from the module, and the
-// consumer needs nothing from fmt but its declarations.)
-//
-// Mixing this textual fmt with an imported fmt elsewhere in the program is exactly what
-// FMT_ATTACH_TO_GLOBAL_MODULE is for; smallstring.cppm requires it and explains why.
+// This is the branch that carries the body, so it is the one that *defines* the formatter
+// specialisation -- the case the note at the top of this file is really about. Textual, always.
 #include <fmt/format.h>
 
 #endif  // !SMALLSTRING_MODULE_INTERFACE

--- a/include/smallstring.hpp
+++ b/include/smallstring.hpp
@@ -5485,19 +5485,16 @@ template <typename Char,
           template <typename, template <class, bool> class, class T, class A, bool N, float G> class Buffer,
           template <typename, bool> class Core, class Traits, class Allocator, bool NullTerminated, float Growth>
 struct fmt::formatter<small::basic_small_string<Char, Buffer, Core, Traits, Allocator, NullTerminated, Growth>>
+    : fmt::formatter<std::string_view>
 {
-    constexpr auto parse(fmt::format_parse_context& ctx) -> fmt::format_parse_context::iterator {
-        auto it = ctx.begin();
-        const auto end = ctx.end();
-        while (it != end && *it != '}') {
-            ++it;
-        }
-        return it;
-    }
+    // Delegate to the string_view formatter, which parses and applies the format spec. A hand-rolled
+    // parse() that merely skips to '}' stores no state, so width, alignment, fill and precision are
+    // silently discarded -- fmt::format("{:>5}", small_string("foo")) would give "foo", not "  foo".
+    using fmt::formatter<std::string_view>::parse;
 
     auto format(const small::basic_small_string<Char, Buffer, Core, Traits, Allocator, NullTerminated>& str,
                 fmt::format_context& ctx) const noexcept {
-        return fmt::format_to(ctx.out(), "{}", std::string_view{str.data(), str.size()});
+        return fmt::formatter<std::string_view>::format({str.data(), str.size()}, ctx);
     }
 };
 

--- a/include/smallstring.hpp
+++ b/include/smallstring.hpp
@@ -30,9 +30,13 @@
 // sits in its global module fragment and a GMF is not re-exported, so `import smallstring;` alone would
 // silently take fmt away from every consumer the moment SMALLSTRING_USE_MODULE is turned on.
 //
-// Keeping the include here costs nothing -- fmt is textual on both sides of the module boundary (or a
-// module on both sides, under STDB_USE_FMT_MODULE), so the declarations are the same entities either
-// way.
+// Keeping the include here costs nothing -- fmt is textual on both sides of the module boundary.
+//
+// Under STDB_USE_FMT_MODULE it is textual on *one* side: the interface unit reads <fmt/format.h>
+// textually no matter what, and only the consumer imports. Those still meet, because fmt's module is
+// required to be built with FMT_ATTACH_TO_GLOBAL_MODULE, which leaves its declarations attached to
+// the global module -- the same entities the interface unit saw. smallstring.cppm #errors if that is
+// not so, and explains why it cannot simply `import fmt;` instead.
 #if defined(STDB_USE_FMT_MODULE)
 #ifndef STDB_FMT_IMPORTED
 #define STDB_FMT_IMPORTED 1

--- a/include/smallstring.hpp
+++ b/include/smallstring.hpp
@@ -68,17 +68,20 @@ import smallstring;
 #include <type_traits>
 #include <utility>
 
-// fmt comes in as a C++20 module only when the consumer asked for it (STDB_USE_FMT_MODULE, off by
-// default). Unconditionally importing it made this header unusable in any build where fmt is an
-// ordinary library -- "fatal error: module 'fmt' not found".
-#if defined(STDB_USE_FMT_MODULE)
-#ifndef STDB_FMT_IMPORTED
-#define STDB_FMT_IMPORTED 1
-import fmt;
-#endif
-#else
+// fmt is textual here, and stays textual even when the rest of the build has fmt as a C++20 module
+// (STDB_USE_FMT_MODULE). This is the branch that carries the *body*, so it is the branch that
+// *defines* fmt::formatter<basic_small_string> -- and that definition derives from
+// fmt::formatter<std::string_view>. Reached through `import fmt;`, that base resolves to fmt's
+// primary template and the header does not compile: "no member named 'parse' in
+// 'fmt::formatter<std::basic_string_view<char>>'", deleted constructor.
+//
+// (The import is fine in the SMALLSTRING_USE_MODULE branch above, and only there, because that
+// branch never parses this body -- the specialisation arrives ready-made from the module, and the
+// consumer needs nothing from fmt but its declarations.)
+//
+// Mixing this textual fmt with an imported fmt elsewhere in the program is exactly what
+// FMT_ATTACH_TO_GLOBAL_MODULE is for; smallstring.cppm requires it and explains why.
 #include <fmt/format.h>
-#endif
 
 #endif  // !SMALLSTRING_MODULE_INTERFACE
 

--- a/include/smallstring.hpp
+++ b/include/smallstring.hpp
@@ -24,6 +24,24 @@
 // in that module's GMF instead.
 #if defined(SMALLSTRING_USE_MODULE) && !defined(SMALLSTRING_MODULE_INTERFACE)
 
+// fmt as well, not just the import. This header has always made <fmt/format.h> visible to whoever
+// includes it, and plenty of code leans on that -- regression/string_test.cc includes only
+// smallstring.hpp and then calls fmt::format. The module cannot carry those declarations across: fmt
+// sits in its global module fragment and a GMF is not re-exported, so `import smallstring;` alone would
+// silently take fmt away from every consumer the moment SMALLSTRING_USE_MODULE is turned on.
+//
+// Keeping the include here costs nothing -- fmt is textual on both sides of the module boundary (or a
+// module on both sides, under STDB_USE_FMT_MODULE), so the declarations are the same entities either
+// way.
+#if defined(STDB_USE_FMT_MODULE)
+#ifndef STDB_FMT_IMPORTED
+#define STDB_FMT_IMPORTED 1
+import fmt;
+#endif
+#else
+#include <fmt/format.h>
+#endif
+
 import smallstring;
 
 #else

--- a/include/smallstring.hpp
+++ b/include/smallstring.hpp
@@ -13,7 +13,6 @@
  */
 
 #pragma once
-#include <fmt/format.h>
 #include <sys/types.h>
 
 #include <cassert>
@@ -30,6 +29,11 @@
 #include <string_view>
 #include <type_traits>
 #include <utility>
+
+#ifndef STDB_FMT_IMPORTED
+#define STDB_FMT_IMPORTED 1
+import fmt;
+#endif
 
 namespace small {
 #ifndef Assert
@@ -5450,13 +5454,19 @@ template <typename Char,
           template <typename, template <class, bool> class, class T, class A, bool N, float G> class Buffer,
           template <typename, bool> class Core, class Traits, class Allocator, bool NullTerminated, float Growth>
 struct fmt::formatter<small::basic_small_string<Char, Buffer, Core, Traits, Allocator, NullTerminated, Growth>>
-    : fmt::formatter<std::string_view>
 {
-    using fmt::formatter<std::string_view>::parse;
+    constexpr auto parse(fmt::format_parse_context& ctx) -> fmt::format_parse_context::iterator {
+        auto it = ctx.begin();
+        const auto end = ctx.end();
+        while (it != end && *it != '}') {
+            ++it;
+        }
+        return it;
+    }
 
     auto format(const small::basic_small_string<Char, Buffer, Core, Traits, Allocator, NullTerminated>& str,
                 fmt::format_context& ctx) const noexcept {
-        return fmt::formatter<std::string_view>::format({str.data(), str.size()}, ctx);
+        return fmt::format_to(ctx.out(), "{}", std::string_view{str.data(), str.size()});
     }
 };
 

--- a/include/smallstring.hpp
+++ b/include/smallstring.hpp
@@ -13,6 +13,22 @@
  */
 
 #pragma once
+// Owned by module `smallstring` when the consumer builds with modules (SMALLSTRING_USE_MODULE).
+//
+// Outside that module the include degrades to the import, so these declarations are not ALSO
+// re-declared in the global module. A header is textual everywhere or module-owned everywhere, never
+// both: mixing the two gives every type here two definitions, and nothing links.
+//
+// `import` is legal in a global module fragment, so a .cppm that reaches this header from its GMF is
+// fine. What is NOT fine is reaching it from inside an `export { }` block for the first time -- put it
+// in that module's GMF instead.
+#if defined(SMALLSTRING_USE_MODULE) && !defined(SMALLSTRING_MODULE_INTERFACE)
+
+import smallstring;
+
+#else
+
+#ifndef SMALLSTRING_MODULE_INTERFACE
 #include <sys/types.h>
 
 #include <cassert>
@@ -42,11 +58,16 @@ import fmt;
 #include <fmt/format.h>
 #endif
 
+#endif  // !SMALLSTRING_MODULE_INTERFACE
+
 namespace small {
 #ifndef Assert
 #define Assert(condition, message) assert((condition) && (message))
 #endif
-namespace {
+// Not an unnamed namespace: entities there have internal linkage, and a C++20 module interface
+// cannot reference an internal-linkage entity from an exported inline function or template
+// ("'kMinAlignSize' has internal linkage and cannot be referenced from an exported ...").
+namespace detail {
 inline constexpr uint64_t kMinAlignSize = 8;  // 64 bits for modern cpu
 /**
  * @brief Aligns a value up to the next multiple of N
@@ -65,7 +86,10 @@ template <uint64_t N>
     return (n + N - 1) & static_cast<uint64_t>(-N);
 }
 
-}  // namespace
+}  // namespace detail
+
+using detail::AlignUpTo;
+using detail::kMinAlignSize;
 
 /**
  * @brief Storage strategy enumeration for small string optimization
@@ -5668,3 +5692,5 @@ struct hash<small::basic_small_string<Char, Buffer, Core, Traits, Allocator, Nul
 };
 
 }  // namespace std
+
+#endif  // owned by module smallstring

--- a/include/smallstring.hpp
+++ b/include/smallstring.hpp
@@ -30,9 +30,16 @@
 #include <type_traits>
 #include <utility>
 
+// fmt comes in as a C++20 module only when the consumer asked for it (STDB_USE_FMT_MODULE, off by
+// default). Unconditionally importing it made this header unusable in any build where fmt is an
+// ordinary library -- "fatal error: module 'fmt' not found".
+#if defined(STDB_USE_FMT_MODULE)
 #ifndef STDB_FMT_IMPORTED
 #define STDB_FMT_IMPORTED 1
 import fmt;
+#endif
+#else
+#include <fmt/format.h>
 #endif
 
 namespace small {

--- a/smallstring.cppm
+++ b/smallstring.cppm
@@ -25,9 +25,30 @@ module;
 // declarations onward in its own BMI.
 #include <sys/types.h>
 
-// fmt is textual: smallstring.hpp specialises fmt::formatter, and fmt is an ordinary library in this
-// build. (It is the one heavy header that has to stay in the fragment; every other module in the tree
-// carries it in its own fragment too.)
+// fmt is textual here, and stays textual even when the consumer imports it (STDB_USE_FMT_MODULE).
+// That asymmetry with the shim in smallstring.hpp is deliberate, and it rests on one thing:
+//
+//   fmt's module must be built with FMT_ATTACH_TO_GLOBAL_MODULE.
+//
+// That macro detaches every fmt declaration from module `fmt` (fmt's own words: "you can mix TUs
+// with either importing or #including the {fmt} API"). So the fmt::formatter this fragment sees and
+// the fmt::formatter an importing consumer sees are the *same* global-module entity, and the
+// fmt::formatter<basic_small_string> specialisation exported below is the one the consumer finds.
+//
+// It cannot be done the other way round. Reaching fmt by `import fmt;` here does not compile: the
+// specialisation derives from fmt::formatter<std::string_view>, and through an import that base
+// resolves to fmt's *primary* template -- "no member named 'parse'", deleted constructor. That is a
+// property of fmt itself, not of smallstring; a TU that does nothing but `import fmt;` and name
+// fmt::formatter<std::string_view> fails the same way, while the identical TU with a textual
+// <fmt/format.h> compiles.
+//
+// Without FMT_ATTACH_TO_GLOBAL_MODULE the mix really is unsound -- the consumer's `import fmt;`
+// meets the global-module fmt declarations baked into this BMI and clang rejects it, "declaration
+// 'basic_appender' attached to named module 'fmt' cannot be attached to other modules" -- so say so
+// here rather than let it surface as that error in someone else's translation unit.
+#if defined(STDB_USE_FMT_MODULE) && !defined(FMT_ATTACH_TO_GLOBAL_MODULE)
+#error "module smallstring needs fmt's module built with FMT_ATTACH_TO_GLOBAL_MODULE: it specialises fmt::formatter through a textual <fmt/format.h>, which only matches an imported fmt when fmt's declarations are attached to the global module."
+#endif
 #include <fmt/format.h>
 
 export module smallstring;

--- a/smallstring.cppm
+++ b/smallstring.cppm
@@ -25,30 +25,10 @@ module;
 // declarations onward in its own BMI.
 #include <sys/types.h>
 
-// fmt is textual here, and stays textual even when the consumer imports it (STDB_USE_FMT_MODULE).
-// That asymmetry with the shim in smallstring.hpp is deliberate, and it rests on one thing:
-//
-//   fmt's module must be built with FMT_ATTACH_TO_GLOBAL_MODULE.
-//
-// That macro detaches every fmt declaration from module `fmt` (fmt's own words: "you can mix TUs
-// with either importing or #including the {fmt} API"). So the fmt::formatter this fragment sees and
-// the fmt::formatter an importing consumer sees are the *same* global-module entity, and the
-// fmt::formatter<basic_small_string> specialisation exported below is the one the consumer finds.
-//
-// It cannot be done the other way round. Reaching fmt by `import fmt;` here does not compile: the
-// specialisation derives from fmt::formatter<std::string_view>, and through an import that base
-// resolves to fmt's *primary* template -- "no member named 'parse'", deleted constructor. That is a
-// property of fmt itself, not of smallstring; a TU that does nothing but `import fmt;` and name
-// fmt::formatter<std::string_view> fails the same way, while the identical TU with a textual
-// <fmt/format.h> compiles.
-//
-// Without FMT_ATTACH_TO_GLOBAL_MODULE the mix really is unsound -- the consumer's `import fmt;`
-// meets the global-module fmt declarations baked into this BMI and clang rejects it, "declaration
-// 'basic_appender' attached to named module 'fmt' cannot be attached to other modules" -- so say so
-// here rather than let it surface as that error in someone else's translation unit.
-#if defined(STDB_USE_FMT_MODULE) && !defined(FMT_ATTACH_TO_GLOBAL_MODULE)
-#error "module smallstring needs fmt's module built with FMT_ATTACH_TO_GLOBAL_MODULE: it specialises fmt::formatter through a textual <fmt/format.h>, which only matches an imported fmt when fmt's declarations are attached to the global module."
-#endif
+// fmt is textual, here and everywhere else in smallstring -- the header we are about to read
+// specialises fmt::formatter, and it is the one heavy header that has to stay in this fragment. The
+// note at the top of include/smallstring.hpp explains why it is never an `import fmt;`, and asserts
+// the FMT_ATTACH_TO_GLOBAL_MODULE that lets a textual read here meet an imported fmt elsewhere.
 #include <fmt/format.h>
 
 export module smallstring;

--- a/smallstring.cppm
+++ b/smallstring.cppm
@@ -1,0 +1,41 @@
+// Module interface for smallstring.
+//
+// The header is the single source of truth; this unit only attaches its declarations to module
+// `smallstring`. See the note at the top of include/smallstring.hpp for the ownership rule.
+module;
+
+// smallstring deliberately calls Assert(), not assert(), so the consumer can substitute its own
+// assertion. Textually that was done by #define-ing Assert before including the header. Modules take
+// that away: the header is an `import` at the consumer, and its macros are baked in *here*, when the
+// interface is compiled. So the hook has to live here.
+//
+// Point SMALLSTRING_PRELUDE at a header that #define-s Assert (and includes whatever that needs).
+// Without it, smallstring.hpp falls back to plain assert() as before.
+#ifdef SMALLSTRING_PRELUDE
+#include SMALLSTRING_PRELUDE
+#endif
+
+// std comes in as `import std.compat` below, NOT as textual libstdc++ headers here.
+//
+// Textual <stdexcept> in this fragment would bake libstdc++'s <string> declarations into the BMI as
+// global-module entities. Any consumer that then reads <string> textually -- directly, or through
+// <fmt/format.h> -- re-declares basic_string.tcc's explicit instantiations on top of them and clang
+// rejects it: "explicit instantiation of 'getline' does not refer to a function template". It reaches
+// consumers that never name smallstring, too, because a module that imports smallstring carries those
+// declarations onward in its own BMI.
+#include <sys/types.h>
+
+// fmt is textual: smallstring.hpp specialises fmt::formatter, and fmt is an ordinary library in this
+// build. (It is the one heavy header that has to stay in the fragment; every other module in the tree
+// carries it in its own fragment too.)
+#include <fmt/format.h>
+
+export module smallstring;
+
+import std.compat;
+
+#define SMALLSTRING_MODULE_INTERFACE 1
+export {
+#include "smallstring.hpp"
+}
+#undef SMALLSTRING_MODULE_INTERFACE

--- a/smallstring.cppm
+++ b/smallstring.cppm
@@ -15,6 +15,20 @@ module;
 #include SMALLSTRING_PRELUDE
 #endif
 
+// And that fallback needs <cassert> -- which is why this include is here rather than in the header.
+//
+// smallstring.hpp does include <cassert>, but only on its textual path: the module-interface path skips
+// the whole include block, and it has to, because it is read from inside an `export { }` block where a
+// first-time #include is not allowed. Its `#ifndef Assert` fallback still expands to assert(), though,
+// so with no SMALLSTRING_PRELUDE to define Assert the interface would not compile -- "use of undeclared
+// identifier 'assert'", once per call site. `import std.compat` cannot rescue it either: assert is a
+// macro, and macros do not cross a module boundary.
+//
+// So the fallback's dependency belongs here, next to the hook it backs. It is a macro, expanded while
+// this unit is preprocessed, so nothing about it reaches importers; <cassert> is just <assert.h>, and
+// carries none of the libstdc++ declarations the note below is about.
+#include <cassert>
+
 // std comes in as `import std.compat` below, NOT as textual libstdc++ headers here.
 //
 // Textual <stdexcept> in this fragment would bake libstdc++'s <string> declarations into the BMI as


### PR DESCRIPTION
smallstring.hpp is 5.6k lines and, through `PlainString`, reaches nearly every translation unit in ClapDB. Textual, every one of them re-parses it. This makes it a C++20 module.

### What is here

- **`smallstring.cppm`** attaches the header's declarations to module `smallstring`. The header stays the single source of truth; the .cppm only wraps it.
- **`smallstring.hpp` gets a shim**: outside the module the include degrades to `import smallstring;`, so its declarations are never both module-attached and global-module. Gated on `SMALLSTRING_USE_MODULE`, so a consumer that does not build with modules is completely unaffected.
- **The `Assert()` hook survives.** smallstring calls `Assert()`, not `assert()`, precisely so a consumer can substitute its own. Modules break the old way of doing that — the header is an `import` at the consumer, and smallstring's macros are fixed when its *interface* is compiled, not at the include site. So the interface takes a `SMALLSTRING_PRELUDE` hook: point it at a header that `#define`s `Assert`. Without it, behaviour is unchanged (plain `assert()`).
- **The unnamed namespace holding `kMinAlignSize` / `AlignUpTo` becomes `small::detail`.** Entities in an unnamed namespace have internal linkage, and a module interface cannot reference an internal-linkage entity from an exported inline function or template.
- **`import fmt;` is guarded.** It was unconditional, so the header could not be used at all in a build where fmt is an ordinary library rather than a C++20 module (`fatal error: module 'fmt' not found`).

### One module-shape detail worth knowing

The interface takes std through `import std.compat`, **not** textual libstdc++ headers in its global module fragment. Textual `<stdexcept>` there bakes libstdc++'s `<string>` declarations into the BMI as global-module entities, and any consumer that then reads `<string>` textually — directly, or through `<fmt/format.h>` — re-declares `basic_string.tcc`'s explicit instantiations on top of them:

    basic_string.tcc: explicit instantiation of 'getline' does not refer to a function template

It reaches consumers that never name smallstring, too, because a module that imports smallstring carries those declarations onward in its own BMI. 22 TUs in ClapDB failed exactly this way before the switch. `<fmt/format.h>` has to stay textual — the header specialises `fmt::formatter` — and that one is fine.

### Validation

Building all of ClapDB against this: fresh 64-core build 6m44s → 6m23s, and `alltests` is 7718/7718 cases / ~1.5M assertions green at 8 and at 128 shards.